### PR TITLE
Add support for fallback SMTP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT = queuepusherl
 PROJECT_NAME = queuepusher
 PROJECT_DESCRIPTION = Micro-service for doing HTTP and SMTP requests.
-PROJECT_VERSION = 0.5.0
+PROJECT_VERSION = 0.6.0
 LOCAL_DEPS = inets ssl
 DEPS = lager cowlib jiffy gen_smtp amqp_client
 TEST_DEPS = meck

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Queuepusherl uses two exchanges:
 Message format
 --------------
 
-The message format is fully described in `priv/schema/push_message.schema` but
-here are two examples for clarity:
+The message format is fully described in `priv/schema/push_message.schema` and
+exemplified below:
 
 E-mail with text and html alternatives. In case the message can't be sent it
 will be sent to "admin@example.com" instead with the error body as message.
@@ -88,7 +88,32 @@ A simple HTTP POST to `http://example.com` with the body set to `foo=bar`.
 }
 ```
 
+Message Format - SMTP
+=====================
+
+An SMTP message needs to contain a `mail` and `smtp` value. In the case where
+there are no `error` value no SMTP request will be done if the primary message
+could not be sent.
+
+As for the `body` of the message it can contain either a simple string that will
+be processed as a `text/plain` unless another `content-type` is explicitly
+specified. If there is a list of bodies each sub-body can, recursively, contain
+either a string or a list of sub-bodies. And unless otherwise specified the
+`content-type` will be assumed to be `multipart/mixed`.
+
+Important to note is that the `to`, `cc` and `bcc` fields for the primary
+message needs to be a list of addresses while the `from` field is only allowed
+to be one address.
+
+In the case of multiple SMTPs specified for the primary message these will all
+be tried in order until one of them succeeds. This means that if the first SMTP
+relay isn't accessible for some reason the second one will be attempted and so
+on.
+
 Versioning
 ----------
 
-Queuepusherl intends to employs [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)
+Queuepusherl intends to employs
+[Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)
+
+// vim: tw=80: ft=markdown

--- a/priv/schema/push_message.schema
+++ b/priv/schema/push_message.schema
@@ -3,6 +3,16 @@
     "title": "Queuepush message",
     "type": "object",
     "definitions": {
+        {
+            "type": "object",
+            "properties": {
+                "relay": { "type": "string" },
+                "port": { "type": "number" },
+                "username": { "type": "string" },
+                "password": { "type": "string" }
+            },
+            "required": [ "relay" ]
+        },
         "extemail": {
             "type": "string",
             "regexp": "^(.*<\\S+@\\S+>|\\S+@\\S+)$"
@@ -92,14 +102,15 @@
                             ]
                         },
                         "smtp": {
-                            "type": "object",
-                            "properties": {
-                                "relay": { "type": "string" },
-                                "port": { "type": "number" },
-                                "username": { "type": "string" },
-                                "password": { "type": "string" }
-                            },
-                            "required": [ "relay", "port", "username", "password" ]
+                            "oneOf": [
+                                {
+                                    "type": "array",
+                                    "items": { "$ref": "#/definitions/smtpsettings" }
+                                },
+                                {
+                                    "$ref": "#/definitions/smtpsettings"
+                                }
+                            ]
                         },
                         "error": {
                             "type": "object",
@@ -111,7 +122,7 @@
                             "required": [ "to", "subject", "body" ]
                         }
                     },
-                    "required": [ "mail", "smtp", "error" ]
+                    "required": [ "mail", "smtp" ]
                 }
             }
         },

--- a/src/smtp/qpusherl_smtp_worker.erl
+++ b/src/smtp/qpusherl_smtp_worker.erl
@@ -1,5 +1,4 @@
 -module(qpusherl_smtp_worker).
-%-behaviour(gen_server).
 
 -export([process_event/1]).
 -export([fail_event/2]).
@@ -13,7 +12,7 @@ fail_event(Event, Errors) ->
 
 send_mail(Event) ->
     Mail = qpusherl_smtp_event:get_mail(Event),
-    Smtp = qpusherl_smtp_event:get_smtp_options(Event),
+    Smtps = qpusherl_smtp_event:get_smtp_options(Event),
     %lager:debug("send_mail(Event = ~p)~nMail: ~p~nSmtp: ~p~n", [Event, Mail,
                                                                            %Smtp]),
     %{A, B, C} = erlang:now(),
@@ -24,27 +23,49 @@ send_mail(Event) ->
              %receive timeout -> ok end,
              %ok
     %end.
-    case gen_smtp_client:send_blocking(Mail, Smtp) of
-        Receipt when is_binary(Receipt) ->
-            {ok, #{<<"Receipt">> => Receipt,
-                   <<"Message">> => <<"SMTP request finished">>}};
-        {error, Type, Message} ->
-            {error, {Type, Message}};
-        {error, Reason} ->
-            {error, {unknown_error, Reason}}
+    send_mail_(Mail, Smtps).
+
+send_mail_(Mail, [SMTP | Rest]) ->
+    Result0 = case gen_smtp_client:send_blocking(Mail, SMTP) of
+                 Receipt when is_binary(Receipt) ->
+                     {ok, #{<<"Receipt">> => Receipt,
+                            <<"Message">> => <<"SMTP request finished">>}};
+                 {error, Type, Message} ->
+                     {error, {Type, Message}};
+                 {error, Reason0} ->
+                     {error, {unknown_error, Reason0}}
+             end,
+    case Result0 of
+        {ok, _} ->
+            Result0;
+        {error, Reason1} ->
+            case Rest of
+                [] ->
+                    {error, [{SMTP, Reason1}]};
+                _ ->
+                    case send_mail_(Mail, Rest) of
+                        {ok, _} = Result1 -> Result1;
+                        {error, Errors} -> {error, [{SMTP, Reason1} | Errors]}
+                    end
+            end
     end.
 
 send_error_mail(Event, Errors) ->
     ErrorMail = qpusherl_smtp_event:get_error_mail(Event, Errors),
     ErrorSmtp = qpusherl_smtp_event:get_error_smtp(Event),
-    lager:debug("send_error_mail(#state{event = ~p})~nErrorMail: ~p~nErrorSmtp: ~p~n", [Event,
-                                                                                        ErrorMail,
-                                                                                        ErrorSmtp]),
-    case gen_smtp_client:send_blocking(ErrorMail, ErrorSmtp) of
-        Receipt when is_binary(Receipt) ->
+    case {ErrorMail, ErrorSmtp} of
+        {undefined, undefined} ->
             ok;
-        {error, Type, Message} ->
-            lager:error("Failed to send error mail: ~p ~p", [Type, Message]);
-        {error, Reason} ->
-            lager:error("Failed to send error mail: ~p", [Reason])
+        {_, _} ->
+            lager:debug("send_error_mail(#state{event = ~p})~nErrorMail: ~p~nErrorSmtp: ~p~n", [Event,
+                                                                                                ErrorMail,
+                                                                                                ErrorSmtp]),
+            case gen_smtp_client:send_blocking(ErrorMail, ErrorSmtp) of
+                Receipt when is_binary(Receipt) ->
+                    ok;
+                {error, Type, Message} ->
+                    lager:error("Failed to send error mail: ~p ~p", [Type, Message]);
+                {error, Reason} ->
+                    lager:error("Failed to send error mail: ~p", [Reason])
+            end
     end.

--- a/src/smtp/qpusherl_smtp_worker.erl
+++ b/src/smtp/qpusherl_smtp_worker.erl
@@ -53,13 +53,10 @@ send_mail_(Mail, [SMTP | Rest]) ->
 send_error_mail(Event, Errors) ->
     ErrorMail = qpusherl_smtp_event:get_error_mail(Event, Errors),
     ErrorSmtp = qpusherl_smtp_event:get_error_smtp(Event),
-    case {ErrorMail, ErrorSmtp} of
-        {undefined, undefined} ->
-            ok;
-        {_, _} ->
-            lager:debug("send_error_mail(#state{event = ~p})~nErrorMail: ~p~nErrorSmtp: ~p~n", [Event,
-                                                                                                ErrorMail,
-                                                                                                ErrorSmtp]),
+    if ErrorMail == undefined orelse ErrorSmtp == undefined -> ok;
+       true -> lager:debug("send_error_mail(#state{event = ~p})~n"
+                           "ErrorMail: ~p~n"
+                           "ErrorSmtp: ~p", [Event, ErrorMail, ErrorSmtp]),
             case gen_smtp_client:send_blocking(ErrorMail, ErrorSmtp) of
                 Receipt when is_binary(Receipt) ->
                     ok;

--- a/test/event_SUITE.erl
+++ b/test/event_SUITE.erl
@@ -166,7 +166,7 @@ execute_http_event_failed(_Config) ->
     {Return, Error} = receive {worker_finished, {fail, X, E}} -> {X, E} end,
     ?assert(is_pid(Return)),
     ?assertMatch({state, _, _, true, _}, State1),
-    ?assertMatch({connection_failed, <<"Test fail">>}, Error),
+    ?assertMatch([{_Source, {connection_failed, <<"Test fail">>}}], Error),
 
     ?assert(meck:validate(httpc)),
     meck:unload(httpc),
@@ -187,7 +187,7 @@ execute_smtp_event_failed(_Config) ->
     {Return, Error} = receive {worker_finished, {fail, Y, E}} -> {Y, E} end,
     ?assert(is_pid(Return)),
     ?assertMatch({state, _, _, true, _}, State1),
-    ?assertMatch({test_error, <<"Test error">>}, Error),
+    ?assertMatch([{_Source, {test_error, <<"Test error">>}}], Error),
 
     ?assert(meck:validate(gen_smtp_client)),
 

--- a/test/smtp_SUITE.erl
+++ b/test/smtp_SUITE.erl
@@ -75,11 +75,11 @@ parse(_Config) ->
                    <<"<admin@localhost>">>,
                    [<<"<foo@example.com>">>],
                    _},
-                  {smtp,
-                   <<"smtp.localdomain">>,
-                   25,
-                   <<"username">>,
-                   <<"password">>},
+                  [{smtp,
+                    <<"smtp.localdomain">>,
+                    25,
+                    <<"username">>,
+                    <<"password">>}],
                   {mailerror,
                    <<"Email <user@localhost>">>,
                    <<"admin@no.host">>,
@@ -89,7 +89,7 @@ parse(_Config) ->
                  }, SmtpEvent),
     ?assertMatch({<<"<admin@localhost>">>, [<<"<foo@example.com>">>], _Mail}, qpusherl_smtp_event:get_mail(SmtpEvent)),
     ?assertMatch({_FromMail, _ToAddress, _Mail}, qpusherl_smtp_event:get_error_mail(SmtpEvent, [])),
-    ?assertMatch([{relay, _}, {port, _}, {username, _}, {password, _}],
+    ?assertMatch([[{relay, _}, {port, _}, {username, _}, {password, _}]],
                  qpusherl_smtp_event:get_smtp_options(SmtpEvent)),
     ok.
 
@@ -138,7 +138,7 @@ simple_mail_1(_Config) ->
      },
     {ok, {smtp_event,
           {mail, From, To, Mail},
-          {smtp, SMTPRelay, _Port, _Username, _Password},
+          [{smtp, SMTPRelay, _Port, _Username, _Password}],
           {mailerror, ErrorTo, _ErrorFrom, ErrorSubject, ErrorMsg, undefined}
          }
     } = qpusherl_smtp_event:parse(TestMail, ?DEFAULT_PARSE_OPTS),


### PR DESCRIPTION
This change also makes the `error` section of SMTP events optional and added changed how the internal error reporting works. This also leads to the errors being returned in the headers on the response queue will look different.
